### PR TITLE
Use LDFLAGS instead of install_name_tool

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -68,18 +68,16 @@ function build_pkg_config {
 function build_zlib_ng {
     if [ -e zlib-stamp ]; then return; fi
     fetch_unpack https://github.com/zlib-ng/zlib-ng/archive/$ZLIB_NG_VERSION.tar.gz zlib-ng-$ZLIB_NG_VERSION.tar.gz
-    (cd zlib-ng-$ZLIB_NG_VERSION \
-        && ./configure --prefix=$BUILD_PREFIX --zlib-compat \
-        && make -j4 \
-        && make install)
-
     if [ -n "$IS_MACOS" ]; then
         # Ensure that on macOS, the library name is an absolute path, not an
         # @rpath, so that delocate picks up the right library (and doesn't need
-        # DYLD_LIBRARY_PATH to be set). The default Makefile doesn't have an
-        # option to control the install_name.
-        install_name_tool -id $BUILD_PREFIX/lib/libz.1.dylib $BUILD_PREFIX/lib/libz.1.dylib
+        # DYLD_LIBRARY_PATH to be set).
+        install_name_flags="-dynamiclib -install_name $BUILD_PREFIX/lib/libz.1.dylib"
     fi
+    (cd zlib-ng-$ZLIB_NG_VERSION \
+        && LDFLAGS="$LDFLAGS $install_name_flags" ./configure --prefix=$BUILD_PREFIX --zlib-compat \
+        && make -j4 \
+        && make install)
     touch zlib-stamp
 }
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/issues/8673

After looking at https://github.com/zlib-ng/zlib-ng/blob/287c4dce22a3244a0e2602d9e5bf0929df74fd27/configure#L473, I thought of using flags as an alternative to using `install_name_tool`.

You may or may not think this is a better solution, just thought I'd offer it.