### PR TITLE
Run selftest directly

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -60,11 +60,11 @@ if [[ "$CIBW_PLATFORM" == "ios" ]]; then
     # Cmake has native support for iOS. However, most of that support is based
     # on using the Xcode builder, which isn't very helpful for most of Pillow's
     # dependencies. Therefore, we lean on the OSX configurations, plus CC/CFLAGS
-    # etc to ensure the right sysroot is selected.
+    # etc. to ensure the right sysroot is selected.
     HOST_CMAKE_FLAGS="-DCMAKE_SYSTEM_NAME=$CMAKE_SYSTEM_NAME -DCMAKE_SYSTEM_PROCESSOR=$GNU_ARCH -DCMAKE_OSX_DEPLOYMENT_TARGET=$IPHONEOS_DEPLOYMENT_TARGET -DCMAKE_OSX_SYSROOT=$IOS_SDK_PATH -DBUILD_SHARED_LIBS=NO"
 
     # Meson needs to be pointed at a cross-platform configuration file
-    # This will be generated once CC etc have been evaluated.
+    # This will be generated once CC etc. have been evaluated.
     HOST_MESON_FLAGS="--cross-file $WORKDIR/meson-cross.txt -Dprefer_static=true -Ddefault_library=static"
 
 elif [[ "$(uname -s)" == "Darwin" ]]; then
@@ -291,7 +291,7 @@ if [[ -n "$IS_MACOS" ]]; then
     mkdir -p "$BUILD_PREFIX/lib"
 
     # Ensure pkg-config is available. This is done *before* setting CC, CFLAGS
-    # etc to ensure that the build is *always* a macOS build, even when building
+    # etc. to ensure that the build is *always* a macOS build, even when building
     # for iOS.
     build_pkg_config
 
@@ -317,7 +317,7 @@ if [[ -n "$IS_MACOS" ]]; then
         # behavior into clang.
         unset IPHONEOS_DEPLOYMENT_TARGET
 
-        # Now that we know CC etc, we can create a meson cross-configuration file
+        # Now that we know CC etc., we can create a meson cross-configuration file
         create_meson_cross_config
     fi
 fi

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -43,10 +43,9 @@ if [[ "$CIBW_PLATFORM" == "ios" ]]; then
 
     IOS_SDK_PATH=$(xcrun --sdk $IOS_SDK --show-sdk-path)
     CMAKE_SYSTEM_NAME=iOS
+    IOS_HOST_TRIPLE=$PLAT-apple-ios$IPHONEOS_DEPLOYMENT_TARGET
     if [[ "$IOS_SDK" == "iphonesimulator" ]]; then
-        IOS_HOST_TRIPLE=$PLAT-apple-ios$IPHONEOS_DEPLOYMENT_TARGET-simulator
-    else
-        IOS_HOST_TRIPLE=$PLAT-apple-ios$IPHONEOS_DEPLOYMENT_TARGET
+        IOS_HOST_TRIPLE=$IOS_HOST_TRIPLE-simulator
     fi
 
     # GNU Autotools doesn't recognize the existence of arm64-apple-ios-simulator
@@ -171,7 +170,6 @@ function build_brotli {
 
 function build_harfbuzz {
     if [ -e harfbuzz-stamp ]; then return; fi
-
     python3 -m pip install meson ninja
 
     local out_dir=$(fetch_unpack https://github.com/harfbuzz/harfbuzz/releases/download/$HARFBUZZ_VERSION/harfbuzz-$HARFBUZZ_VERSION.tar.xz harfbuzz-$HARFBUZZ_VERSION.tar.xz)

--- a/.gitignore
+++ b/.gitignore
@@ -80,10 +80,6 @@ docs/_build/
 # JetBrains
 .idea
 
-# Files downloaded as part of the build process
-pillow-depends-main.zip
-pillow-test-images.zip
-
 # Extra test images installed from python-pillow/test-images
 Tests/images/README.md
 Tests/images/crash_1.tif

--- a/Tests/oss-fuzz/test_fuzzers.py
+++ b/Tests/oss-fuzz/test_fuzzers.py
@@ -10,11 +10,8 @@ import pytest
 from PIL import Image, features
 from Tests.helper import skip_unless_feature
 
-if sys.platform.startswith("win32") or sys.platform in {"ios", "android"}:
-    pytest.skip(
-        "Fuzzer doesn't run on Windows or mobile",
-        allow_module_level=True,
-    )
+if sys.platform.startswith("win32") or sys.platform == "ios":
+    pytest.skip("Fuzzer doesn't run on Windows or iOS", allow_module_level=True)
 
 libjpeg_turbo_version = features.version("libjpeg_turbo")
 if libjpeg_turbo_version is not None:

--- a/Tests/test_main.py
+++ b/Tests/test_main.py
@@ -7,7 +7,7 @@ import sys
 import pytest
 
 
-@pytest.mark.skipif(sys.platform == "ios", reason="Not required on mobile")
+@pytest.mark.skipif(sys.platform == "ios", reason="Processes not supported on iOS")
 @pytest.mark.parametrize(
     "args, report",
     ((["PIL"], False), (["PIL", "--report"], True), (["PIL.report"], True)),

--- a/Tests/test_main.py
+++ b/Tests/test_main.py
@@ -7,10 +7,7 @@ import sys
 import pytest
 
 
-@pytest.mark.skipif(
-    sys.platform in {"ios", "android"},
-    reason="Not required on mobile",
-)
+@pytest.mark.skipif(sys.platform == "ios", reason="Not required on mobile")
 @pytest.mark.parametrize(
     "args, report",
     ((["PIL"], False), (["PIL", "--report"], True), (["PIL.report"], True)),

--- a/checks/check_wheel.py
+++ b/checks/check_wheel.py
@@ -51,8 +51,6 @@ def test_wheel_features() -> None:
     elif sys.platform == "ios":
         # Can't distribute raqm due to licensing, and there's no system version;
         # fribidi and harfbuzz won't be available if raqm isn't available.
-        expected_features.remove("fribidi")
-        expected_features.remove("raqm")
-        expected_features.remove("harfbuzz")
+        expected_features -= {"raqm", "fribidi", "harfbuzz"}
 
     assert set(features.get_supported_features()) == expected_features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,10 @@ test-sources = [
   "pyproject.toml",
   "selftest.py",
 ]
-test-command = "python -m pytest -vv selftest.py checks/check_wheel.py Tests"
+test-command = [
+  "python -m selftest",
+  "python -m pytest checks/check_wheel.py Tests",
+]
 
 # There's no numpy wheel for iOS (yet...)
 test-requires = [  ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,11 +112,11 @@ test-requires = [
 xbuild-tools = [  ]
 
 [tool.cibuildwheel.macos]
-# Disable platform guessing on macOS to avoid picking up homebrew etc
+# Disable platform guessing on macOS to avoid picking up Homebrew etc.
 config-settings = "raqm=enable raqm=vendor fribidi=vendor imagequant=disable platform-guessing=disable"
 
 [tool.cibuildwheel.macos.environment]
-# Isolate macOS build environment from homebrew etc
+# Isolate macOS build environment from Homebrew etc.
 PATH = "$(pwd)/build/deps/darwin/bin:$(dirname $(which python3)):/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin"
 
 [tool.cibuildwheel.ios]


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/9030

- I don't see why `.map_metadata_keys(metadata("Pillow"))` is needed in Tests/test_pyroma.py
- I've removed references to `sys.platform` being "android"
- .gitignore already [ignores the downloaded zips](https://github.com/python-pillow/Pillow/blob/2954964cd2b70c463d75bd7f828c7bb7f3802bf2/.gitignore#L94-L96)
- I was able to move the checks back into the Tests directory, by using https://github.com/pypa/cibuildwheel/pull/2432