### PR TITLE
For iOS x86_64, do not use dav1d and build aom without optimizations

### DIFF
--- a/checks/check_wheel.py
+++ b/checks/check_wheel.py
@@ -27,10 +27,6 @@ def test_wheel_modules() -> None:
         # tkinter is not available on iOS
         expected_modules.remove("tkinter")
 
-        # libavif is not available on x86_64 iOS simulators
-        if platform.machine() == "x86_64":
-            expected_modules.remove("avif")
-
     assert set(features.get_supported_modules()) == expected_modules
 
 


### PR DESCRIPTION
This should allow libavif to work for iOS x86-64 in https://github.com/python-pillow/Pillow/pull/9117