### PR TITLE
Revert "Upgrade iOS wheels from macos-13 to macos-14"

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -113,11 +113,6 @@ LIBXCB_VERSION=1.17.0
 BROTLI_VERSION=1.1.0  # Patched; next release won't need patching. See patch file.
 LIBAVIF_VERSION=1.3.0
 
-function macos_intel_cross_build_setup {
-    # Prevent multibuild from disabling cross compiling on arm64
-    :
-}
-
 function build_pkg_config {
     if [ -e pkg-config-stamp ]; then return; fi
     # This essentially duplicates the Homebrew recipe.


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/9249

This change is no longer needed.